### PR TITLE
fix: correct asset base path

### DIFF
--- a/apps/planvsfondo/vite.config.ts
+++ b/apps/planvsfondo/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
-  base: process.env.VITE_BASE || '/',
+  // La aplicación se sirve bajo /planvsfondo/, por lo que se fija la base
+  // para que los recursos estáticos apunten correctamente y eviten errores 404
+  base: '/planvsfondo/',
   server: { host: true, port: 5173 }
 })


### PR DESCRIPTION
## Summary
- fix static asset 404 by setting Vite base to `/planvsfondo/`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdc89e4650832685040970ec42227a