### PR TITLE
Corrige símbolo € duplicado en retiradas anuales

### DIFF
--- a/apps/planvsfondo/src/App.tsx
+++ b/apps/planvsfondo/src/App.tsx
@@ -790,7 +790,7 @@ export default function App() {
                       return (
                         <tr key={`plan-${w}`} className="border-t bg-gray-50">
                           <td className="py-2 pr-3">
-                            <div className="font-medium">Retirar {fmtEUR(w)} € netos al año</div>
+                            <div className="font-medium">Retirar {fmtEUR(w)} netos al año</div>
                             <div className="text-xs text-gray-500">Total neto con pensión: {fmtEUR(pensionNet + w)}</div>
                           </td>
                           <td className="py-2 pr-3 text-center">
@@ -837,7 +837,7 @@ export default function App() {
                       return (
                         <tr key={`fund-${w}`} className="border-t bg-white">
                           <td className="py-2 pr-3">
-                            <div className="font-medium">Retirar {fmtEUR(w)} € netos al año</div>
+                            <div className="font-medium">Retirar {fmtEUR(w)} netos al año</div>
                             <div className="text-xs text-gray-500">Total neto con pensión: {fmtEUR(pensionNet + w)}</div>
                           </td>
                           <td className="py-2 pr-3 text-center">{fmtEUR(fs.totalNet)}</td>


### PR DESCRIPTION
## Summary
- Ajusta texto de retiradas para evitar mostrar el símbolo € dos veces

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bed1049f088326bc457494161d682e