### PR TITLE
feat: add annual gross column and favicon

### DIFF
--- a/apps/comparadorhipotecas/index.html
+++ b/apps/comparadorhipotecas/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Comparador de Hipotecas</title>
+    <link rel="icon" type="image/png" href="/landing/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="/landing/apple-touch-icon.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/planvsfondo/index.html
+++ b/apps/planvsfondo/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>App</title>
+    <link rel="icon" type="image/png" href="/landing/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="/landing/apple-touch-icon.png" />
   </head>
   <body class="bg-gray-50">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add Bruto Anual column with per-scenario breakdown
- compute annual gross values and show plan/fund split when reinvesting IRPF savings
- reuse landing favicon in tools

## Testing
- `npm test` (planvsfondo) *(fails: Missing script)*
- `npm run build` (planvsfondo)
- `npm test` (comparadorhipotecas) *(fails: Missing script)*
- `npm run build` (comparadorhipotecas)


------
https://chatgpt.com/codex/tasks/task_e_68bee1cbb86c83269b6677600de8dbd7