### PR TITLE
Add sortable controls to listadofondos table columns

### DIFF
--- a/apps/listadofondos/src/App.tsx
+++ b/apps/listadofondos/src/App.tsx
@@ -166,20 +166,6 @@ const PERFORMANCE_LABELS: readonly PerformanceKey[] = [
 
 const RATIO_LABELS: readonly RatioPeriod[] = ["1Y", "3Y", "5Y"];
 
-const NAME_COLUMN_MIN_WIDTH = 320;
-const ISIN_COLUMN_MIN_WIDTH = 120;
-const TER_COLUMN_MIN_WIDTH = 90;
-const COMMENT_COLUMN_MIN_WIDTH = 240;
-const METRIC_COLUMN_WIDTH = 88;
-const METRIC_COLUMN_COUNT =
-  PERFORMANCE_LABELS.length + RATIO_LABELS.length * 2;
-const TABLE_MIN_WIDTH =
-  NAME_COLUMN_MIN_WIDTH +
-  ISIN_COLUMN_MIN_WIDTH +
-  TER_COLUMN_MIN_WIDTH +
-  COMMENT_COLUMN_MIN_WIDTH +
-  METRIC_COLUMN_WIDTH * METRIC_COLUMN_COUNT;
-
 const API_BASE = (import.meta.env.VITE_API_BASE ?? "/listadofondos/api").replace(/\/$/, "");
 const ENABLE_MOCK_DATA =
   String(import.meta.env.VITE_ENABLE_MOCK_DATA ?? "true").toLowerCase() !== "false";
@@ -557,18 +543,11 @@ function renderMetricCells<T extends string>(
     if (options.addLeftBoundary && columns[0] === label) {
       classes.push("border-l", "border-gray-400");
     }
-    const style: React.CSSProperties = {
-      minWidth: METRIC_COLUMN_WIDTH,
-      width: METRIC_COLUMN_WIDTH,
-    };
-    if (background) {
-      style.backgroundColor = background;
-    }
     return (
       <td
         key={`${keyPrefix}-${label}`}
         className={classes.join(" ")}
-        style={style}
+        style={background ? { backgroundColor: background } : undefined}
       >
         {formatValue(values[label])}
       </td>
@@ -919,16 +898,12 @@ function Section({
         ) : null}
       </div>
       <div className="-mx-4 overflow-x-auto pb-4 sm:mx-0">
-        <table
-          className="w-full border-separate border-spacing-y-1 border-spacing-x-0.5 text-sm text-gray-800"
-          style={{ minWidth: TABLE_MIN_WIDTH }}
-        >
+        <table className="w-full border-separate border-spacing-y-1 border-spacing-x-0.5 text-sm text-gray-800">
           <thead>
             <tr className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
               <th
                 rowSpan={2}
                 className="px-3 py-2 max-w-[320px] bg-white/70 text-center rounded-tl-2xl"
-                style={{ minWidth: NAME_COLUMN_MIN_WIDTH }}
               >
                 <div className="flex items-center justify-center gap-1">
                   <span>{texts.name}</span>
@@ -943,7 +918,6 @@ function Section({
               <th
                 rowSpan={2}
                 className="px-2.5 py-2 whitespace-nowrap bg-white/70 text-center"
-                style={{ minWidth: ISIN_COLUMN_MIN_WIDTH }}
               >
                 <div className="flex items-center justify-center gap-1">
                   <span>{texts.isin}</span>
@@ -958,7 +932,6 @@ function Section({
               <th
                 rowSpan={2}
                 className="px-1.5 py-2 whitespace-nowrap bg-white/70 text-center"
-                style={{ minWidth: TER_COLUMN_MIN_WIDTH }}
               >
                 <div className="flex items-center justify-center gap-1">
                   <span>{texts.ter}</span>
@@ -1000,7 +973,6 @@ function Section({
               <th
                 rowSpan={2}
                 className="px-3 py-2 bg-white/70 text-center rounded-tr-2xl"
-                style={{ minWidth: COMMENT_COLUMN_MIN_WIDTH }}
               >
                 {texts.comment}
               </th>
@@ -1012,7 +984,6 @@ function Section({
                   className={`px-1.5 py-1.5 bg-white/70 text-center ${
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
-                  style={{ minWidth: METRIC_COLUMN_WIDTH, width: METRIC_COLUMN_WIDTH }}
                 >
                   <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
@@ -1037,7 +1008,6 @@ function Section({
                   className={`px-1.5 py-1.5 bg-white/70 text-center ${
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
-                  style={{ minWidth: METRIC_COLUMN_WIDTH, width: METRIC_COLUMN_WIDTH }}
                 >
                   <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
@@ -1062,7 +1032,6 @@ function Section({
                   className={`px-1.5 py-1.5 bg-white/70 text-center ${
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
-                  style={{ minWidth: METRIC_COLUMN_WIDTH, width: METRIC_COLUMN_WIDTH }}
                 >
                   <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
@@ -1115,7 +1084,6 @@ function Section({
                       className={`relative px-3 py-2 bg-white/95 backdrop-blur max-w-[320px] overflow-visible align-top ${
                         tooltipOpen ? "z-20" : ""
                       }`}
-                      style={{ minWidth: NAME_COLUMN_MIN_WIDTH }}
                     >
                       <div className="flex flex-col items-start gap-1">
                         <a
@@ -1191,13 +1159,11 @@ function Section({
                     </td>
                     <td
                       className="px-3 py-2 bg-white/95 backdrop-blur whitespace-nowrap text-gray-600 text-xs sm:text-[13px] align-middle"
-                      style={{ minWidth: ISIN_COLUMN_MIN_WIDTH }}
                     >
                       {formatValue(row.isin)}
                     </td>
                     <td
                       className="px-1.5 py-2 bg-white/95 backdrop-blur whitespace-nowrap font-semibold text-gray-700 text-center align-middle"
-                      style={{ minWidth: TER_COLUMN_MIN_WIDTH }}
                     >
                       {formatValue(row.ter)}
                     </td>
@@ -1221,7 +1187,6 @@ function Section({
                     )}
                     <td
                       className="px-3 py-2 bg-white/95 backdrop-blur text-gray-600 text-xs sm:text-[13px] leading-snug align-middle"
-                      style={{ minWidth: COMMENT_COLUMN_MIN_WIDTH }}
                     >
                       {formatValue(row.comment) || texts.commentPlaceholder}
                     </td>

--- a/apps/listadofondos/src/App.tsx
+++ b/apps/listadofondos/src/App.tsx
@@ -166,6 +166,20 @@ const PERFORMANCE_LABELS: readonly PerformanceKey[] = [
 
 const RATIO_LABELS: readonly RatioPeriod[] = ["1Y", "3Y", "5Y"];
 
+const NAME_COLUMN_MIN_WIDTH = 320;
+const ISIN_COLUMN_MIN_WIDTH = 120;
+const TER_COLUMN_MIN_WIDTH = 90;
+const COMMENT_COLUMN_MIN_WIDTH = 240;
+const METRIC_COLUMN_WIDTH = 88;
+const METRIC_COLUMN_COUNT =
+  PERFORMANCE_LABELS.length + RATIO_LABELS.length * 2;
+const TABLE_MIN_WIDTH =
+  NAME_COLUMN_MIN_WIDTH +
+  ISIN_COLUMN_MIN_WIDTH +
+  TER_COLUMN_MIN_WIDTH +
+  COMMENT_COLUMN_MIN_WIDTH +
+  METRIC_COLUMN_WIDTH * METRIC_COLUMN_COUNT;
+
 const API_BASE = (import.meta.env.VITE_API_BASE ?? "/listadofondos/api").replace(/\/$/, "");
 const ENABLE_MOCK_DATA =
   String(import.meta.env.VITE_ENABLE_MOCK_DATA ?? "true").toLowerCase() !== "false";
@@ -543,11 +557,18 @@ function renderMetricCells<T extends string>(
     if (options.addLeftBoundary && columns[0] === label) {
       classes.push("border-l", "border-gray-400");
     }
+    const style: React.CSSProperties = {
+      minWidth: METRIC_COLUMN_WIDTH,
+      width: METRIC_COLUMN_WIDTH,
+    };
+    if (background) {
+      style.backgroundColor = background;
+    }
     return (
       <td
         key={`${keyPrefix}-${label}`}
         className={classes.join(" ")}
-        style={background ? { backgroundColor: background } : undefined}
+        style={style}
       >
         {formatValue(values[label])}
       </td>
@@ -898,12 +919,16 @@ function Section({
         ) : null}
       </div>
       <div className="-mx-4 overflow-x-auto pb-4 sm:mx-0">
-        <table className="min-w-full border-separate border-spacing-y-1 border-spacing-x-0.5 text-sm text-gray-800">
+        <table
+          className="w-full border-separate border-spacing-y-1 border-spacing-x-0.5 text-sm text-gray-800"
+          style={{ minWidth: TABLE_MIN_WIDTH }}
+        >
           <thead>
             <tr className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">
               <th
                 rowSpan={2}
-                className="px-3 py-2 min-w-[300px] max-w-[320px] bg-white/70 text-center rounded-tl-2xl"
+                className="px-3 py-2 max-w-[320px] bg-white/70 text-center rounded-tl-2xl"
+                style={{ minWidth: NAME_COLUMN_MIN_WIDTH }}
               >
                 <div className="flex items-center justify-center gap-1">
                   <span>{texts.name}</span>
@@ -918,6 +943,7 @@ function Section({
               <th
                 rowSpan={2}
                 className="px-2.5 py-2 whitespace-nowrap bg-white/70 text-center"
+                style={{ minWidth: ISIN_COLUMN_MIN_WIDTH }}
               >
                 <div className="flex items-center justify-center gap-1">
                   <span>{texts.isin}</span>
@@ -932,6 +958,7 @@ function Section({
               <th
                 rowSpan={2}
                 className="px-1.5 py-2 whitespace-nowrap bg-white/70 text-center"
+                style={{ minWidth: TER_COLUMN_MIN_WIDTH }}
               >
                 <div className="flex items-center justify-center gap-1">
                   <span>{texts.ter}</span>
@@ -972,7 +999,8 @@ function Section({
               </th>
               <th
                 rowSpan={2}
-                className="px-3 py-2 min-w-[200px] bg-white/70 text-center rounded-tr-2xl"
+                className="px-3 py-2 bg-white/70 text-center rounded-tr-2xl"
+                style={{ minWidth: COMMENT_COLUMN_MIN_WIDTH }}
               >
                 {texts.comment}
               </th>
@@ -984,6 +1012,7 @@ function Section({
                   className={`px-1.5 py-1.5 bg-white/70 text-center ${
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
+                  style={{ minWidth: METRIC_COLUMN_WIDTH, width: METRIC_COLUMN_WIDTH }}
                 >
                   <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
@@ -1008,6 +1037,7 @@ function Section({
                   className={`px-1.5 py-1.5 bg-white/70 text-center ${
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
+                  style={{ minWidth: METRIC_COLUMN_WIDTH, width: METRIC_COLUMN_WIDTH }}
                 >
                   <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
@@ -1032,6 +1062,7 @@ function Section({
                   className={`px-1.5 py-1.5 bg-white/70 text-center ${
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
+                  style={{ minWidth: METRIC_COLUMN_WIDTH, width: METRIC_COLUMN_WIDTH }}
                 >
                   <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
@@ -1081,9 +1112,10 @@ function Section({
                 return (
                   <tr key={tooltipId} className="align-middle">
                     <td
-                      className={`relative px-3 py-2 bg-white/95 backdrop-blur min-w-[300px] max-w-[320px] overflow-visible align-top ${
+                      className={`relative px-3 py-2 bg-white/95 backdrop-blur max-w-[320px] overflow-visible align-top ${
                         tooltipOpen ? "z-20" : ""
                       }`}
+                      style={{ minWidth: NAME_COLUMN_MIN_WIDTH }}
                     >
                       <div className="flex flex-col items-start gap-1">
                         <a
@@ -1157,10 +1189,16 @@ function Section({
                         )}
                       </div>
                     </td>
-                    <td className="px-3 py-2 bg-white/95 backdrop-blur whitespace-nowrap text-gray-600 text-xs sm:text-[13px] align-middle">
+                    <td
+                      className="px-3 py-2 bg-white/95 backdrop-blur whitespace-nowrap text-gray-600 text-xs sm:text-[13px] align-middle"
+                      style={{ minWidth: ISIN_COLUMN_MIN_WIDTH }}
+                    >
                       {formatValue(row.isin)}
                     </td>
-                    <td className="px-1.5 py-2 bg-white/95 backdrop-blur whitespace-nowrap font-semibold text-gray-700 text-center align-middle">
+                    <td
+                      className="px-1.5 py-2 bg-white/95 backdrop-blur whitespace-nowrap font-semibold text-gray-700 text-center align-middle"
+                      style={{ minWidth: TER_COLUMN_MIN_WIDTH }}
+                    >
                       {formatValue(row.ter)}
                     </td>
                     {renderMetricCells(
@@ -1181,7 +1219,10 @@ function Section({
                       volatilityStats,
                       { metric: "volatility", addLeftBoundary: true },
                     )}
-                    <td className="px-3 py-2 bg-white/95 backdrop-blur text-gray-600 text-xs sm:text-[13px] leading-snug align-middle">
+                    <td
+                      className="px-3 py-2 bg-white/95 backdrop-blur text-gray-600 text-xs sm:text-[13px] leading-snug align-middle"
+                      style={{ minWidth: COMMENT_COLUMN_MIN_WIDTH }}
+                    >
                       {formatValue(row.comment) || texts.commentPlaceholder}
                     </td>
                   </tr>

--- a/apps/listadofondos/src/App.tsx
+++ b/apps/listadofondos/src/App.tsx
@@ -617,7 +617,7 @@ function SortControl({
         type="button"
         aria-label={ascLabel}
         aria-pressed={ascActive}
-        className={`group inline-flex h-4 w-4 items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 ${
+        className={`group inline-flex h-3 w-3 items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 ${
           ascActive ? "text-cyan-600" : "text-gray-300 hover:text-gray-500"
         }`}
         onClick={() => onChange(ascActive ? null : "asc")}
@@ -630,7 +630,7 @@ function SortControl({
           strokeWidth={2.4}
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="h-3 w-3"
+          className="h-2.5 w-2.5"
         >
           <path d="M6 14L12 8l6 6" />
         </svg>
@@ -639,7 +639,7 @@ function SortControl({
         type="button"
         aria-label={descLabel}
         aria-pressed={descActive}
-        className={`group inline-flex h-4 w-4 items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 ${
+        className={`group inline-flex h-3 w-3 items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 ${
           descActive ? "text-cyan-600" : "text-gray-300 hover:text-gray-500"
         }`}
         onClick={() => onChange(descActive ? null : "desc")}
@@ -652,7 +652,7 @@ function SortControl({
           strokeWidth={2.4}
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="h-3 w-3"
+          className="h-2.5 w-2.5"
         >
           <path d="M6 10l6 6 6-6" />
         </svg>
@@ -889,7 +889,7 @@ function Section({
                 rowSpan={2}
                 className="px-3 py-2 min-w-[300px] max-w-[320px] bg-white/70 text-center rounded-tl-2xl"
               >
-                <div className="flex flex-col items-center justify-center gap-1">
+                <div className="flex items-center justify-center gap-1">
                   <span>{texts.name}</span>
                   <SortControl
                     lang={lang}
@@ -903,7 +903,7 @@ function Section({
                 rowSpan={2}
                 className="px-2.5 py-2 whitespace-nowrap bg-white/70 text-center"
               >
-                <div className="flex flex-col items-center justify-center gap-1">
+                <div className="flex items-center justify-center gap-1">
                   <span>{texts.isin}</span>
                   <SortControl
                     lang={lang}
@@ -917,7 +917,7 @@ function Section({
                 rowSpan={2}
                 className="px-1.5 py-2 whitespace-nowrap bg-white/70 text-center"
               >
-                <div className="flex flex-col items-center justify-center gap-1">
+                <div className="flex items-center justify-center gap-1">
                   <span>{texts.ter}</span>
                   <SortControl
                     lang={lang}
@@ -969,7 +969,7 @@ function Section({
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
                 >
-                  <div className="flex flex-col items-center justify-center gap-0.5">
+                  <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
                     <SortControl
                       lang={lang}
@@ -993,7 +993,7 @@ function Section({
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
                 >
-                  <div className="flex flex-col items-center justify-center gap-0.5">
+                  <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
                     <SortControl
                       lang={lang}
@@ -1017,7 +1017,7 @@ function Section({
                     index === 0 ? "border-l border-gray-400" : ""
                   }`}
                 >
-                  <div className="flex flex-col items-center justify-center gap-0.5">
+                  <div className="flex items-center justify-center gap-1">
                     <span>{displayMetricLabel(label)}</span>
                     <SortControl
                       lang={lang}


### PR DESCRIPTION
## Summary
- add sorting utilities and state so fund rows can be ordered by textual and numeric columns
- render stacked arrow sort controls on each sortable header while leaving comments unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e579823ad083268410c2935dd849ed