### PR TITLE
Auto refresh listadofondos data when hitting refresh route

### DIFF
--- a/apps/listadofondos/src/App.tsx
+++ b/apps/listadofondos/src/App.tsx
@@ -109,7 +109,7 @@ const TEXTS = {
     searchPlaceholder: "Buscar...",
     searchAriaLabel: "Buscar en la tabla",
     dataNote:
-      "Los datos se obtienen automáticamente de Morningstar una vez al día y pueden actualizarse manualmente.",
+      "Los datos se obtienen automáticamente de Morningstar cada 4 horas y pueden actualizarse manualmente.",
     langES: "ES",
     langEN: "EN",
     back: "Volver a Herramientas",
@@ -148,7 +148,8 @@ const TEXTS = {
     sectionDescription: "",
     searchPlaceholder: "Search...",
     searchAriaLabel: "Search within the table",
-    dataNote: "Data is automatically retrieved from Morningstar once per day and can be refreshed manually.",
+    dataNote:
+      "Data is automatically retrieved from Morningstar every 4 hours and can be refreshed manually.",
     langES: "ES",
     langEN: "EN",
     back: "Back to Tools",

--- a/apps/listadofondos/src/App.tsx
+++ b/apps/listadofondos/src/App.tsx
@@ -80,7 +80,7 @@ function isPerformanceOrSharpeSortKey(key: SortKey) {
 
 const TEXTS = {
   es: {
-    title: "Listado y Comparativa de Fondos y Planes de Pensiones",
+    title: "Comparativa de Fondos y Planes de Pensiones",
     subtitle:
       "Estos son mis fondos favoritos y planes de pensiones, que sigo e invierto en ellos desde hace años.",
     refresh: "Refrescar datos",
@@ -120,7 +120,7 @@ const TEXTS = {
       "Mostrando datos de ejemplo por falta de conexión con la API. Las cifras pueden no coincidir con los últimos datos reales.",
   },
   en: {
-    title: "Fund and Pension Plan List and Comparison",
+    title: "Fund and Pension Plan Comparison",
     subtitle:
       "Review performance, Sharpe ratios, volatility and TER for each fund or pension plan.",
     refresh: "Refresh data",

--- a/apps/listadofondos/src/App.tsx
+++ b/apps/listadofondos/src/App.tsx
@@ -1218,7 +1218,6 @@ export default function App() {
   const texts = useTexts(lang);
   const [status, setStatus] = useState<ApiStatus>("idle");
   const [data, setData] = useState<ApiPayload | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [usingMockData, setUsingMockData] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -1277,9 +1276,7 @@ export default function App() {
 
     const run = async () => {
       if (shouldAutoRefresh) {
-        setRefreshing(true);
         await fetchData(true);
-        setRefreshing(false);
         if (typeof window !== "undefined") {
           const basePath = window.location.pathname.replace(
             /\/refrescardatos_dragner\/?$/,
@@ -1294,12 +1291,6 @@ export default function App() {
 
     void run();
   }, [fetchData, shouldAutoRefresh]);
-
-  const onRefresh = async () => {
-    setRefreshing(true);
-    await fetchData(true);
-    setRefreshing(false);
-  };
 
   return (
     <div className="relative min-h-screen text-gray-900">
@@ -1368,14 +1359,6 @@ export default function App() {
                   </span>
                 </label>
               </div>
-              <button
-                type="button"
-                onClick={onRefresh}
-                disabled={refreshing}
-                className="inline-flex items-center justify-center rounded-xl bg-cyan-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-cyan-700 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto w-full"
-              >
-                {refreshing ? texts.refreshing : texts.refresh}
-              </button>
             </div>
             {status === "ready" && data && (
               <p className="text-xs text-gray-500">

--- a/services/listadofondos-api/src/server.js
+++ b/services/listadofondos-api/src/server.js
@@ -613,15 +613,17 @@ function parseMorningstarRating(html) {
   return Math.max(0, Math.min(5, rating));
 }
 
-function isSameDay(isoA, isoB) {
+function isWithinHours(isoA, isoB, hours) {
   if (!isoA || !isoB) return false;
-  const a = new Date(isoA);
-  const b = new Date(isoB);
-  return (
-    a.getUTCFullYear() === b.getUTCFullYear() &&
-    a.getUTCMonth() === b.getUTCMonth() &&
-    a.getUTCDate() === b.getUTCDate()
-  );
+  if (typeof hours !== "number" || !Number.isFinite(hours) || hours <= 0) {
+    return false;
+  }
+  const a = new Date(isoA).getTime();
+  const b = new Date(isoB).getTime();
+  if (Number.isNaN(a) || Number.isNaN(b)) return false;
+  const diffMs = Math.abs(b - a);
+  const limitMs = hours * 60 * 60 * 1000;
+  return diffMs <= limitMs;
 }
 
 function stripQuotes(value) {
@@ -772,8 +774,8 @@ async function buildPayload() {
 
 async function getData() {
   const cache = await readCache();
-  const today = new Date().toISOString();
-  if (cache && isSameDay(cache.lastUpdated, today)) return cache;
+  const nowIso = new Date().toISOString();
+  if (cache && isWithinHours(cache.lastUpdated, nowIso, 4)) return cache;
   return await buildPayload();
 }
 


### PR DESCRIPTION
## Summary
- trigger the data refresh flow automatically when visiting /listadofondos/refrescardatos_dragner
- reuse the existing fetch routine and return the user to the standard listing view once the refresh completes

## Testing
- npm --prefix apps/listadofondos run build

------
https://chatgpt.com/codex/tasks/task_e_68e58b1389a4832686727711119c4589